### PR TITLE
attempt change with relativeness in prepare.py

### DIFF
--- a/prepare.py
+++ b/prepare.py
@@ -273,6 +273,7 @@ def filemap_and_recordsprep(dest_dir, source_dir, skip):
     for filename in os.listdir(dest_dir):
         if filename.endswith(".json"):
 
+            
             # creating the parent and child directory for the files to get mapped to
             parent_name = filename.rstrip(".json")
             parent_dir = os.path.join(dest_dir, parent_name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "nda-bids-upload"
 version = "0.0.0"
 description =  "NDA BIDS Upload Tool "
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 authors = [
     {name = "nimh-dsst", email = ""}
 ]
@@ -14,7 +14,6 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -23,7 +22,7 @@ dependencies = [
     "mkdocs-material>=9.0.0",
     "PyYAML>=6.0",
     "pandas>=1.5.0",
-    "file-mapper @ git+https://github.com/bendhouseart/file-mapper.git@refactor-pythonic",
+    "file-mapper @ git+https://github.com/bendhouseart/file-mapper.git",
     "nda-tools",
 ]
 
@@ -71,4 +70,4 @@ dev-dependencies = [
 ]
 
 [tool.uv.sources]
-file-mapper = {git = "https://github.com/bendhouseart/file-mapper.git", branch = "refactor-pythonic"}
+file-mapper = {git = "https://github.com/bendhouseart/file-mapper.git", branch = "main"}

--- a/records.py
+++ b/records.py
@@ -71,7 +71,7 @@ def records_sanity_check(input):
 
     dest_dir = os.path.dirname(parent)
     lookup_csv = os.path.join(dest_dir, "lookup.csv")
-    manifest_script = os.path.join(dest_dir, "manifest-data", "nda_manifests.py")
+    manifest_script = os.path.join(HERE, "manifest-data", "nda_manifests.py")
 
     # check if manifest_script exists
     if not os.path.isfile(manifest_script):
@@ -212,7 +212,7 @@ def cli(input):
     # setting easy use variables from argparse
     parent = os.path.abspath(os.path.realpath(input))
     dest_dir = os.path.dirname(parent)
-    manifest_script = os.path.join(dest_dir, "manifest-data", "nda_manifests.py")
+    manifest_script = os.path.join(HERE, "manifest-data", "nda_manifests.py")
     lookup_csv = os.path.join(dest_dir, "lookup.csv")
 
     # grab parent's basename
@@ -426,7 +426,8 @@ def cli(input):
             f"Files prepped at {input} with {parent}.complete_records.csv are invalid, run\n"
             f"vtcdm {input}.complete_records.csv -m {input} --verbose\n"
             f"for more details on how to fix"
-            )
+        )
+
 
 # Usage:
 # run_vtcmd('image03_sourcedata.pet.pet.complete_records.csv', 'image03_sourcedata.pet.pet/')


### PR DESCRIPTION
Previously the absolute path to the symlink generated nda dataset would be placed in the manifest. This update makes manifest file paths relative to dataset to ridiculous looking file tree duplication via the manifest paths.  